### PR TITLE
feat: `--cached-only` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ you can get more reliable benchmarks.
 deno run --allow-net --allow-read=. --allow-write=. jsr:@david/bench-registry/cli
 ```
 
+### Options
+
+* `--cached-only` - Run using only packages that have previously been cached.
+
 ## Setting up benchmark
 
 Use an `.npmrc` with:

--- a/cli.ts
+++ b/cli.ts
@@ -1,6 +1,12 @@
 import { startServer } from "./mod.ts";
+import { parseArgs } from "@std/cli/parse-args";
+
+const args = parseArgs(Deno.args, {
+  boolean: ["cached-only"]
+});
 
 const server = startServer({
   useMemCache: true,
+  cachedOnly: args["cached-only"],
 });
 console.error(`Server listening on http://localhost:${server.addr.port}`);

--- a/deno.json
+++ b/deno.json
@@ -6,8 +6,9 @@
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.0",
+    "@std/cli": "jsr:@std/cli@^1.0.15",
     "@std/encoding": "jsr:@std/encoding@^1.0.1",
-    "@std/fs": "jsr:@std/fs@^0.229.3",
+    "@std/fs": "jsr:@std/fs@^1",
     "@std/path": "jsr:@std/path@^1.0.0"
   },
   "exports": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,48 +1,39 @@
 {
-  "version": "3",
-  "packages": {
-    "specifiers": {
-      "jsr:@std/assert@^1.0.0": "jsr:@std/assert@1.0.0",
-      "jsr:@std/encoding@^1.0.1": "jsr:@std/encoding@1.0.1",
-      "jsr:@std/fs@^0.229.3": "jsr:@std/fs@0.229.3",
-      "jsr:@std/internal@^1.0.1": "jsr:@std/internal@1.0.1",
-      "jsr:@std/path@1.0.0-rc.1": "jsr:@std/path@1.0.0-rc.1",
-      "jsr:@std/path@^1.0.0": "jsr:@std/path@1.0.0"
+  "version": "4",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.0",
+    "jsr:@std/cli@^1.0.15": "1.0.15",
+    "jsr:@std/encoding@^1.0.1": "1.0.1",
+    "jsr:@std/internal@^1.0.1": "1.0.1",
+    "jsr:@std/path@1": "1.0.0"
+  },
+  "jsr": {
+    "@std/assert@1.0.0": {
+      "integrity": "0e4f6d873f7f35e2a1e6194ceee39686c996b9e5d134948e644d35d4c4df2008",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
     },
-    "jsr": {
-      "@std/assert@1.0.0": {
-        "integrity": "0e4f6d873f7f35e2a1e6194ceee39686c996b9e5d134948e644d35d4c4df2008",
-        "dependencies": [
-          "jsr:@std/internal@^1.0.1"
-        ]
-      },
-      "@std/encoding@1.0.1": {
-        "integrity": "5955c6c542ebb4ce6587c3b548dc71e07a6c27614f1976d1d3887b1196cf4e65"
-      },
-      "@std/fs@0.229.3": {
-        "integrity": "783bca21f24da92e04c3893c9e79653227ab016c48e96b3078377ebd5222e6eb",
-        "dependencies": [
-          "jsr:@std/path@1.0.0-rc.1"
-        ]
-      },
-      "@std/internal@1.0.1": {
-        "integrity": "6f8c7544d06a11dd256c8d6ba54b11ed870aac6c5aeafff499892662c57673e6"
-      },
-      "@std/path@1.0.0": {
-        "integrity": "77fcb858b6e38777d1154df0f02245ba0b07e2c40ca3c0eec57c9233188c2d21"
-      },
-      "@std/path@1.0.0-rc.1": {
-        "integrity": "b8c00ae2f19106a6bb7cbf1ab9be52aa70de1605daeb2dbdc4f87a7cbaf10ff6"
-      }
+    "@std/cli@1.0.15": {
+      "integrity": "e79ba3272ec710ca44d8342a7688e6288b0b88802703f3264184b52893d5e93f"
+    },
+    "@std/encoding@1.0.1": {
+      "integrity": "5955c6c542ebb4ce6587c3b548dc71e07a6c27614f1976d1d3887b1196cf4e65"
+    },
+    "@std/internal@1.0.1": {
+      "integrity": "6f8c7544d06a11dd256c8d6ba54b11ed870aac6c5aeafff499892662c57673e6"
+    },
+    "@std/path@1.0.0": {
+      "integrity": "77fcb858b6e38777d1154df0f02245ba0b07e2c40ca3c0eec57c9233188c2d21"
     }
   },
-  "remote": {},
   "workspace": {
     "dependencies": [
-      "jsr:@std/assert@^1.0.0",
+      "jsr:@std/assert@1",
+      "jsr:@std/cli@^1.0.15",
       "jsr:@std/encoding@^1.0.1",
-      "jsr:@std/fs@^0.229.3",
-      "jsr:@std/path@^1.0.0"
+      "jsr:@std/fs@1",
+      "jsr:@std/path@1"
     ]
   }
 }


### PR DESCRIPTION
Adds a `--cached-only` flag for running the bench registry using only previously cached data.